### PR TITLE
Add export to file feature

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -11,3 +11,4 @@ nalgebra = {version = "0.20", features = ["mint"] }
 mint = "0.5"
 cgmath = { version = "0.17", features = ["mint"]}
 rand = "0.7"
+image= "0.23"

--- a/src/action_processer_utils.rs
+++ b/src/action_processer_utils.rs
@@ -27,7 +27,11 @@ fn configure_command(action_processer_builder: &mut ActionProcesserBuilder) {
         .with_inputaction(
             Mode::Command,
             InputAction::new(KeyCode::E, ActionType::ChangeMode(Mode::Edit)),
-        );
+        )
+        .with_inputaction(
+            Mode::Command, 
+            InputAction::new(KeyCode::W, ActionType::SaveImage))
+        ;
 }
 
 fn configure_edit(action_processer_builder: &mut ActionProcesserBuilder) {

--- a/src/action_processer_utils.rs
+++ b/src/action_processer_utils.rs
@@ -5,6 +5,7 @@ use crate::edit_type::EditType;
 use crate::input_action::InputAction;
 use crate::item::ItemType;
 use crate::mode::Mode;
+use crate::command_type::CommandType;
 
 use ggez::input::keyboard::KeyCode;
 
@@ -30,7 +31,8 @@ fn configure_command(action_processer_builder: &mut ActionProcesserBuilder) {
         )
         .with_inputaction(
             Mode::Command, 
-            InputAction::new(KeyCode::W, ActionType::SaveImage))
+            InputAction::new(KeyCode::Colon, ActionType::ChangeMode(Mode::CommandInput))
+        )
         ;
 }
 
@@ -313,6 +315,21 @@ fn configure_edit_scale_uniform(action_processer_builder: &mut ActionProcesserBu
         );
 }
 
+pub fn configure_command_input(action_processer_builder: &mut ActionProcesserBuilder){
+    action_processer_builder
+    .with_inputaction(
+        Mode::CommandInput,
+        InputAction::new(KeyCode::Escape, ActionType::ChangeMode(Mode::Command)))
+    .with_inputaction(
+        Mode::CommandInput,
+        InputAction::new(KeyCode::W, ActionType::CommandType(CommandType::SaveImage)),
+    )
+    .with_inputaction(
+        Mode::CommandInput,
+        InputAction::new(KeyCode::Return, ActionType::RunCommand),
+    );
+}
+
 pub fn configure_default(action_processer_builder: &mut ActionProcesserBuilder) {
     configure_modes(action_processer_builder);
     configure_command(action_processer_builder);
@@ -325,4 +342,5 @@ pub fn configure_default(action_processer_builder: &mut ActionProcesserBuilder) 
     configure_edit_rotate(action_processer_builder);
     configure_edit_scale(action_processer_builder);
     configure_edit_scale_uniform(action_processer_builder);
+    configure_command_input(action_processer_builder);
 }

--- a/src/action_type.rs
+++ b/src/action_type.rs
@@ -11,4 +11,5 @@ pub enum ActionType {
     Rotate(Direction),
     Scale(Direction),
     ScaleUniform(Direction),
+    SaveImage,
 }

--- a/src/action_type.rs
+++ b/src/action_type.rs
@@ -1,6 +1,7 @@
 use crate::direction::Direction;
 use crate::item::ItemType;
 use crate::mode::Mode;
+use crate::command_type::CommandType;
 
 #[derive(Clone, Copy)]
 pub enum ActionType {
@@ -11,5 +12,6 @@ pub enum ActionType {
     Rotate(Direction),
     Scale(Direction),
     ScaleUniform(Direction),
-    SaveImage,
+    CommandType(CommandType),
+    RunCommand,
 }

--- a/src/app.rs
+++ b/src/app.rs
@@ -151,7 +151,11 @@ impl event::EventHandler for App {
                             self.current_edit_index,
                             item::Image::scale_uniform,
                         );
-                    } //_ => {},
+                    }
+                    ActionType::SaveImage => {
+                        self.board.save_image(ctx);
+                    }
+                    //_ => {},
                 }
             }
         }

--- a/src/board.rs
+++ b/src/board.rs
@@ -1,7 +1,10 @@
 use crate::direction::Direction;
 use crate::item::Image;
 use crate::item_collection::ItemCollection;
-use ggez::{Context, GameResult};
+use ggez::{Context, GameResult, graphics};
+use ggez::conf;
+use image::{DynamicImage, ImageBuffer};
+
 pub struct Board {
     pub item_collection: ItemCollection,
 }
@@ -27,6 +30,42 @@ impl Board {
                 edit_func(image, dt, direction, is_fast);
             }
         }
+    }
+
+    pub fn save_image(&mut self, ctx: &mut Context){
+        //TODO: Add actual error handling, no unwrap() shenanigans!
+
+        let (graphic_width, graphic_height) = graphics::drawable_size(ctx);
+        
+        let buffer_canvas = graphics::Canvas::new(ctx, graphic_width as u16, graphic_height as u16, conf::NumSamples::One).ok();
+        
+        //draw to canvas
+        graphics::set_canvas(ctx, buffer_canvas.as_ref());
+
+        self.draw(ctx).unwrap();
+        ggez::graphics::present(ctx).unwrap();
+
+        // capture the image from canvas
+        let canvas = buffer_canvas.unwrap();
+        let canvas_image = canvas.image();
+
+        // convert the image to rgba 8 bit vector
+        let image_rgba = canvas_image.to_rgba8(ctx).unwrap();
+
+        // turn the raw rgba8 into DynamicImage
+        let image_buffer = DynamicImage::ImageRgba8(ImageBuffer::from_raw(graphic_width as u32, graphic_height as u32, image_rgba).unwrap());
+
+        // flip the image cause the raw image vector is flipped.. dunno why *shrug*
+        let image_buffer = image_buffer.flipv();
+
+        //save the image
+        //TODO: change it to parameter
+        image_buffer.save("/home/riyan/Pictures/test.png").unwrap();
+
+        //return drawing to screen
+        graphics::set_canvas(ctx, Option::None);
+
+
     }
 
     pub fn draw(&self, ctx: &mut Context) -> GameResult {

--- a/src/board.rs
+++ b/src/board.rs
@@ -4,6 +4,7 @@ use crate::item_collection::ItemCollection;
 use ggez::{Context, GameResult, graphics};
 use ggez::conf;
 use image::{DynamicImage, ImageBuffer};
+use std::path::Path;
 
 pub struct Board {
     pub item_collection: ItemCollection,
@@ -32,8 +33,8 @@ impl Board {
         }
     }
 
-    pub fn save_image(&mut self, ctx: &mut Context, path: &String){
-        //TODO: Add actual error handling, no unwrap() shenanigans!
+    pub fn save_image(&mut self, ctx: &mut Context, path: &String) {
+        //TODO: Add better error handling and bubling the error into UI
 
         let (graphic_width, graphic_height) = graphics::drawable_size(ctx);
         
@@ -44,27 +45,31 @@ impl Board {
         self.draw(ctx).unwrap();
         ggez::graphics::present(ctx).unwrap();
 
-        // capture the image from canvas
+        // capture the image from canvas into raw vector
         let canvas = buffer_canvas.unwrap();
         let canvas_image = canvas.into_inner();
 
-        // convert the image to rgba 8 bit vector
+        // convert the image to DynamicImage from raw vector
         let image_rgba = canvas_image.to_rgba8(ctx).unwrap();
-
-        // turn the raw rgba8 into DynamicImage
         let image_buffer = DynamicImage::ImageRgba8(ImageBuffer::from_raw(graphic_width as u32, graphic_height as u32, image_rgba).unwrap());
 
-        // flip the image cause the raw image vector is flipped.. dunno why *shrug*
+        // flip the image because the raw image vector is flipped.. dunno why ¯\_(ツ)_/¯
         let image_buffer = image_buffer.flipv();
 
         //save the image
-        //TODO: change it to parameter and convert path to OS specific
-        image_buffer.save(path).unwrap();
+        let image_path = Path::new(path).as_os_str();
+        
+        match image_buffer.save(image_path) {
+            Ok(_) => {
+                println!("Image saved successfully!")
+            }
+            Err(err) => {
+                println!("Failed to save image : {:?}", err);
+            }
+        }
 
         //return to drawing into screen
         graphics::set_canvas(ctx, Option::None);
-
-
     }
 
     pub fn draw(&self, ctx: &mut Context) -> GameResult {

--- a/src/board.rs
+++ b/src/board.rs
@@ -32,22 +32,21 @@ impl Board {
         }
     }
 
-    pub fn save_image(&mut self, ctx: &mut Context){
+    pub fn save_image(&mut self, ctx: &mut Context, path: &String){
         //TODO: Add actual error handling, no unwrap() shenanigans!
 
         let (graphic_width, graphic_height) = graphics::drawable_size(ctx);
         
         let buffer_canvas = graphics::Canvas::new(ctx, graphic_width as u16, graphic_height as u16, conf::NumSamples::One).ok();
         
-        //draw to canvas
+        //divert drawing into canvas
         graphics::set_canvas(ctx, buffer_canvas.as_ref());
-
         self.draw(ctx).unwrap();
         ggez::graphics::present(ctx).unwrap();
 
         // capture the image from canvas
         let canvas = buffer_canvas.unwrap();
-        let canvas_image = canvas.image();
+        let canvas_image = canvas.into_inner();
 
         // convert the image to rgba 8 bit vector
         let image_rgba = canvas_image.to_rgba8(ctx).unwrap();
@@ -59,10 +58,10 @@ impl Board {
         let image_buffer = image_buffer.flipv();
 
         //save the image
-        //TODO: change it to parameter
-        image_buffer.save("/home/riyan/Pictures/test.png").unwrap();
+        //TODO: change it to parameter and convert path to OS specific
+        image_buffer.save(path).unwrap();
 
-        //return drawing to screen
+        //return to drawing into screen
         graphics::set_canvas(ctx, Option::None);
 
 

--- a/src/command_state.rs
+++ b/src/command_state.rs
@@ -1,0 +1,6 @@
+#[derive(PartialEq)]
+pub enum CommandState{
+    None,
+    Listen,
+    Run,
+}

--- a/src/command_type.rs
+++ b/src/command_type.rs
@@ -1,0 +1,5 @@
+#[derive(PartialEq, Eq, Hash, Clone, Copy, Debug)]
+pub enum CommandType{
+    None,
+    SaveImage,
+}

--- a/src/graphics.rs
+++ b/src/graphics.rs
@@ -1,1 +1,2 @@
 pub mod mode_visualizer;
+pub mod input_visualizer;

--- a/src/graphics/input_visualizer.rs
+++ b/src/graphics/input_visualizer.rs
@@ -1,0 +1,68 @@
+use crate::text_input::TextInput;
+
+use ggez;
+use ggez::graphics::{DrawMode, DrawParam, Mesh, Rect, Text, TextFragment};
+use ggez::GameResult;
+use nalgebra;
+
+pub struct InputVisualizer {
+    text: Text,
+    rect_mesh: Mesh,
+    rect: Rect,
+    prefix: String,
+}
+
+impl InputVisualizer {
+    pub fn new(ctx: &mut ggez::Context, text: &TextInput) -> Self {
+        let rect = Rect::new(0.0, 0.0, 100.0, 100.0);
+        // todo: fix error handling
+        let rect_mesh =
+            ggez::graphics::Mesh::new_rectangle(ctx, DrawMode::fill(), rect, ggez::graphics::BLACK)
+                .unwrap();
+        let mut input_visualizer = InputVisualizer {
+            rect_mesh,
+            text: Text::new(TextFragment::default()),
+            rect,
+            prefix: String::from(""),
+        };
+        input_visualizer.change(ctx, text);
+        input_visualizer
+    }
+
+    pub fn change(&mut self, ctx: &mut ggez::Context, text: &TextInput) {
+
+        let mut text_content = String::from("");
+
+        if self.prefix.len() > 0 {
+            text_content  = format!("{} : {}", self.prefix, text.content.to_string())
+        }
+
+        self.text = Text::new(TextFragment {
+            text: text_content,
+            color: Some(ggez::graphics::WHITE),
+            ..Default::default()
+        });
+        let (text_w, text_h) = self.text.dimensions(ctx);
+        self.rect = Rect::new(0.0, 0.0, text_w as f32, text_h as f32);
+        self.rect_mesh = ggez::graphics::Mesh::new_rectangle(
+            ctx,
+            DrawMode::fill(),
+            self.rect,
+            ggez::graphics::BLACK,
+        )
+        .unwrap();
+    }
+
+    pub fn set_prefix(&mut self, prefix: String){
+        self.prefix = prefix;
+    }
+
+    pub fn draw(&self, ctx: &mut ggez::Context) -> GameResult {
+        let screen_rect = ggez::graphics::screen_coordinates(ctx);
+        let mut draw_param = DrawParam::default();
+        draw_param.dest = nalgebra::Point2::new(0.0, screen_rect.h - self.rect.h - 20.0).into();
+        ggez::graphics::draw(ctx, &self.rect_mesh, draw_param)?;
+        ggez::graphics::draw(ctx, &self.text, draw_param)?;
+        Ok(())
+    }
+}

--- a/src/main.rs
+++ b/src/main.rs
@@ -22,6 +22,9 @@ mod key_state;
 mod keyboard_input_tracker;
 mod mode;
 mod mode_history;
+mod text_input;
+mod command_type;
+mod command_state;
 
 use app::App;
 

--- a/src/mode.rs
+++ b/src/mode.rs
@@ -5,6 +5,7 @@ use std::hash::Hash;
 #[derive(PartialEq, Eq, Hash, Clone, Copy, Debug)]
 pub enum Mode {
     Command,
+    CommandInput,
     Any,
     Insert,
     Edit,

--- a/src/text_input.rs
+++ b/src/text_input.rs
@@ -1,0 +1,27 @@
+use std::char;
+use std::string::String;
+
+#[derive(Clone)]
+pub struct TextInput{
+    pub content: String
+}
+
+impl TextInput{
+    pub fn new() -> Self{
+        TextInput {
+            content: String::from(""),
+        }
+    }
+
+    pub fn clear(&mut self) {
+        self.content = String::from("");
+    }
+
+    pub fn add(&mut self, character: char){
+        self.content.push(character);
+    }
+
+    pub fn del(&mut self){
+        self.content.pop();
+    }
+}


### PR DESCRIPTION
Hi Tantan, just wanna say i love your idea. I've been wanting to dip my hand into rust for a while now and after watching your vid i thought this is a good chance for me to do so. I'm still new to rust so i hope i implemented the feature correctly.

Preview:
![aaa](https://user-images.githubusercontent.com/8548422/89718436-c8a33280-d9e8-11ea-9f87-675d8ca0e877.gif)

Steps:
1. In `Command` mode press colon `:` to enter `CommandInput` mode,
2. In `CommandInput` mode press `W` then enter the path,
3. Press `enter` to save the image.

I'm using [image](https://docs.rs/image/0.23.8/image/) crate to encode the image.
ggez does provide encoding feature but only png format is currently supported so i choose image crate instead since it's support more formats.

I've only tested it on linux (Pop_OS 20.04) so i don't know if it'll work on windows or mac.

And also sorry, i butchered your code.
